### PR TITLE
oneplus3: add the system partition back to early mount fstab

### DIFF
--- a/arch/arm/boot/dts/qcom/15801/msm8996-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/15801/msm8996-mtp.dtsi
@@ -940,7 +940,14 @@
 	android {
 		fstab {
 			/delete-node/ vendor;
-			/delete-node/ system;
+			system {
+				compatible = "android,system";
+				dev = "/dev/block/platform/soc/624000.ufshc/by-name/system";
+				type = "ext4";
+				mnt_flags = "ro,barrier=1,discard";
+				fsmgr_flags = "wait,verify=/dev/block/platform/soc/624000.ufshc/by-name/reserve2";
+				status = "ok";
+			};
 		};
 	};
 };


### PR DESCRIPTION
This reverts commit 17ece71cea1f2b0226ad500293f76df91d38e646.

Signed-off-by: anupritaisno1 <www.anuprita804@gmail.com>